### PR TITLE
Introduce the greater number validator

### DIFF
--- a/public/views/partials/lib/validations/greater.liquid
+++ b/public/views/partials/lib/validations/greater.liquid
@@ -1,0 +1,35 @@
+{% comment %}
+  params: @given
+          @compared_value
+          @field_name
+          @allow_equal
+          @message_gt
+          @message_gte
+          @key
+          @c
+{% endcomment %}
+{% liquid
+  assign allow_equal = allow_equal | default: false
+  assign result = false
+
+  if allow_equal
+    if given >= compared_value
+      assign result = true
+    endif
+  else
+    if given > compared_value
+      assign result = true
+    endif
+  endif
+
+  if result == false
+    if allow_equal
+      assign message = message_gte | default: key | default: 'modules/core/validation.number.greater_than_or_equal' | t: count: compared_value
+    else
+      assign message = message_gt | default: key | default: 'modules/core/validation.number.greater_than' | t: count: compared_value
+    endif
+    function c = 'modules/core/lib/helpers/register_error', contract: c, field_name: field_name, message: message
+  endif
+  return c
+%}
+


### PR DESCRIPTION
# Description

It can compare two integers and report errors. Whether equal values are allowed can be configured by the `allow_equal: true` parameter.
Translation keys of the error message can be given for specific comparisons:
- `message_gte`: error message when the value is greater than or equal
- `message_gt`: error message when the value is greater than
- `key`: when you want the same message in both of the previous cases

The assertion looks like: `given` must be greater than (or equal) `compared_value`

## Issue ticket number and link
Required by PR https://github.com/Platform-OS/pcbs/pull/82

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
