### PR TITLE
Add missing field_name param to exist_in_db validtor

### DIFF
--- a/public/views/partials/lib/validations/exist_in_db.liquid
+++ b/public/views/partials/lib/validations/exist_in_db.liquid
@@ -1,5 +1,6 @@
 {% comment %}
-  params: @property_name
+  params: @field_name
+          @property_name
           @property_value
           @scope_name
           @scope_value


### PR DESCRIPTION
# Description

Add missing field_name param to exist_in_db validtor's description.

## Issue ticket number and link


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
