### PR TITLE
Check if value is numeric

### DIFF
--- a/public/translations/en/validation.yml
+++ b/public/translations/en/validation.yml
@@ -15,6 +15,7 @@ en:
       is: is the wrong length (should be %{count} characters)
       blank: is blank
     number:
+      invalid: '`%{value}` is not a number'
       greater_than: must be greater than %{count}
       greater_than_or_equal: must be greater than or equal to %{count}
       less_than: must be less than %{count}

--- a/public/views/partials/lib/validations/number.liquid
+++ b/public/views/partials/lib/validations/number.liquid
@@ -12,6 +12,18 @@
 {% endcomment %}
 {% liquid
   assign number = number | default: object[field_name]
+%}
+{% capture test1 %}{{ number }}{% endcapture %}
+{% capture test2 %}{{ test1 | plus: 0 }}{% endcapture %}
+{% liquid
+  if test1 != test2
+    assign message = message | default: 'modules/core/validation.number.invalid' | t: value: number
+    function c = 'modules/core/lib/helpers/register_error', contract: c, field_name: field_name, message: message
+
+    return c
+  endif
+
+  assign number = number | plus: 0
 
   if lt != null and number >= lt
     assign message = message_lt | default: 'modules/core/validation.number.lt' | t: count: lt, value: number


### PR DESCRIPTION
# Description

The number validator raises a Liquid error, when the value is a string. For example:
```liquid
assign object = '{"field1": "one-two-three"}' | parse_json
function c = 'modules/core/lib/validations/number', c: c, object: object, field_name: 'field1', gt: 0
```

**Result Before**
`Liquid error: comparison of String with 2147483647 failed`

**Result After**
```json
{
    "valid": false,
    "errors": {
        "field1": [
            "`one-two-three` is not a number"
        ]
    }
}
```

## Issue ticket number and link
_None_

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
